### PR TITLE
WISKEL.cre

### DIFF
--- a/Blackhearts/Scripts/WISKEL.BAF
+++ b/Blackhearts/Scripts/WISKEL.BAF
@@ -1,0 +1,25 @@
+IF
+	OR(3)
+		Dead("WILLYRK")  // Sazazir
+		HPLT("WILLYRK",1)  // Sazazir
+		!InMyArea("WILLYRK")  // Sazazir
+THEN
+	RESPONSE #100
+		Kill(Myself)
+		ApplyDamage(Myself,999,CRUSHING)
+END
+
+IF
+	!See(NearestEnemyOf(Myself))
+THEN
+	RESPONSE #100
+		MoveToObject(NearestEnemyOf(Myself))
+END
+
+IF
+	See(NearestEnemyOf(Myself))
+THEN
+	RESPONSE #100
+		AttackOneRound(NearestEnemyOf(Myself))
+END
+

--- a/Blackhearts/setup-Blackhearts.tp2
+++ b/Blackhearts/setup-Blackhearts.tp2
@@ -285,6 +285,7 @@ COMPILE ~Blackhearts/Scripts/WIMIMIC.baf~
 COMPILE ~Blackhearts/Scripts/WICHDETH.baf~
 COMPILE ~Blackhearts/Scripts/WIILLIMG.baf~
 COMPILE ~Blackhearts/Scripts/WICHERI2.baf~ EVALUATE_BUFFER
+COMPILE ~Blackhearts/Scripts/WISKEL.BAF~
 
 EXTEND_TOP ~%BaldursGate_Undercellars_BCS%.bcs~ ~Blackhearts/Scripts/BG0112.baf~ EVALUATE_BUFFER
 EXTEND_TOP ~%Undercity_BCS%.bcs~ ~Blackhearts/Scripts/BG0123.baf~ EVALUATE_BUFFER
@@ -794,6 +795,7 @@ WRITE_ASCII DEATHVAR ~WILLYRK~ (8)
 COPY ~Blackhearts/CRE/WISKEL.cre~ ~override/WISKEL.cre~
 	SAY NAME1 @3309
 	SAY NAME2 @3309
+WRITE_ASCII SCRIPT_CLASS ~WISKEL~ (8)
 WRITE_ASCII DEATHVAR ~WISKEL~ (8)
 
 COPY ~Blackhearts/CRE/WIOGRE01.cre~ ~override/WIOGRE01.cre~


### PR DESCRIPTION
WISKEL.cre was using original game script with original Llyrk.cre death vars.

Assign new WISKEL.BAF to WISKEL.cre with WILLYRK.cre (Sazazir) check instead.

https://forums.beamdog.com/discussion/comment/1214511/#Comment_1214511